### PR TITLE
My-bond-env

### DIFF
--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -656,7 +656,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
-  Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
+  const Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
   unsigned int beginAtomIdx = rootedBond->getBeginAtomIdx();
   unsigned int endAtomIdx = rootedBond->getEndAtomIdx();
   

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -656,9 +656,9 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
     throw ValueErrorException("bad bond index");
   }
   PATH_TYPE res;
-  const Bond &rootedBond = *mol.getBondWithIdx(rootedAtBond);
-  unsigned int beginAtomIdx = rootedBond.getBeginAtomIdx();
-  unsigned int endAtomIdx = rootedBond.getEndAtomIdx();
+  Bond *rootedBond = mol.getBondWithIdx(rootedAtBond);
+  unsigned int beginAtomIdx = rootedBond->getBeginAtomIdx();
+  unsigned int endAtomIdx = rootedBond->getEndAtomIdx();
   
   if (atomMap) {
     atomMap->clear();

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -565,7 +565,7 @@ namespace {
       unsigned int maxRolledRadius;
       for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
         if (nbrStack.empty()) {
-          return maxRolledRadius; 
+          return maxRolledRadius;
         }
 
         std::list<std::pair<int, int>> nextLayer;

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -679,7 +679,7 @@ PATH_TYPE findBondEnvironmentOfRadiusN(
   // Perform BFS to find the environment
   boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
   res.push_back(rootedAtBond);
-  bondsIn.set(rootedAtBond);
+  bondsIn.set(rootedAtBond); 
   unsigned int maxRolledRadius = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, 
                                                           bondsIn, useHs, atomMap);
   if (enforceSize) {

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -565,7 +565,7 @@ namespace {
       unsigned int maxRolledRadius;
       for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
         if (nbrStack.empty()) {
-          return maxRolledRadius;
+          break;
         }
 
         std::list<std::pair<int, int>> nextLayer;

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -562,8 +562,8 @@ namespace {
     boost::dynamic_bitset<> &bondsIn, bool useHs, 
     std::unordered_map<unsigned int, unsigned int> *atomMap) {
       
-      unsigned int maxRolledRadius;
-      for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
+      unsigned int i;
+      for (i = 0; i < radius; ++i) {
         if (nbrStack.empty()) {
           break;
         }
@@ -581,14 +581,14 @@ namespace {
             int oAtom = mol.getBondWithIdx(bondIdx)->getOtherAtomIdx(startAtom);
             if (atomMap) {
               if (atomMap->find(oAtom) == atomMap->end()) {
-                (*atomMap)[oAtom] = maxRolledRadius + 1;
+                (*atomMap)[oAtom] = i + 1;
               } else {
-                (*atomMap)[oAtom] = std::min(atomMap->at(oAtom), maxRolledRadius + 1);
+                (*atomMap)[oAtom] = std::min(atomMap->at(oAtom), i + 1);
               }
             }
             // if we're going to do another iteration, then push the neighbors from
             // this round onto the stack
-            if (maxRolledRadius < radius - 1) {
+            if (i < radius - 1) {
               for (const auto bond : mol.atomBonds(mol.getAtomWithIdx(oAtom))) {
                 if (!bondsIn.test(bond->getIdx())) {
                   if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(oAtom))
@@ -602,7 +602,7 @@ namespace {
         }
         nbrStack = std::move(nextLayer);
       }
-      return maxRolledRadius;
+      return i;
     }
 }
 

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -565,7 +565,7 @@ namespace {
       unsigned int maxRolledRadius;
       for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
         if (nbrStack.empty()) {
-          return maxRolledRadius;
+          return maxRolledRadius; 
         }
 
         std::list<std::pair<int, int>> nextLayer;

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -565,7 +565,7 @@ namespace {
       unsigned int maxRolledRadius;
       for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
         if (nbrStack.empty()) {
-          break;
+          return maxRolledRadius;
         }
 
         std::list<std::pair<int, int>> nextLayer;

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -538,6 +538,74 @@ findAllPathsOfLengthN(const ROMol &mol, unsigned int targetLen, bool useBonds,
                                    rootedAtAtom)[targetLen];
 }
 
+namespace {
+  void prepareNeighborStack(
+    const ROMol &mol, unsigned int atomIdx,
+    std::list<std::pair<int, int>> &nbrStack, bool useHs) {
+      // This function is to prepare the neighbor stack for the
+      // findEnvironmentOfRadiusN function.
+      ROMol::OEDGE_ITER beg, end;
+      boost::tie(beg, end) = mol.getAtomBonds(mol.getAtomWithIdx(atomIdx));
+      while (beg != end) {
+        const Bond *bond = mol[*beg];
+        if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(atomIdx))
+                         ->getAtomicNum() != 1) {
+          nbrStack.emplace_back(atomIdx, bond->getIdx());
+        }
+        ++beg;
+      }
+    }
+  
+  unsigned int findEnvironmentOfRadiusN(
+    const ROMol &mol, unsigned int radius, PATH_TYPE &path,
+    std::list<std::pair<int, int>> &nbrStack, 
+    boost::dynamic_bitset<> &bondsIn, bool useHs, 
+    std::unordered_map<unsigned int, unsigned int> *atomMap) {
+      
+      unsigned int maxRolledRadius;
+      for (maxRolledRadius = 0; maxRolledRadius < radius; ++maxRolledRadius) {
+        if (nbrStack.empty()) {
+          break;
+        }
+
+        std::list<std::pair<int, int>> nextLayer;
+        while (!nbrStack.empty()) {
+          int bondIdx, startAtom;
+          boost::tie(startAtom, bondIdx) = nbrStack.front();
+          nbrStack.pop_front();
+          if (!bondsIn.test(bondIdx)) {
+            bondsIn.set(bondIdx);
+            path.push_back(bondIdx);
+
+            // add the next set of neighbors:
+            int oAtom = mol.getBondWithIdx(bondIdx)->getOtherAtomIdx(startAtom);
+            if (atomMap) {
+              if (atomMap->find(oAtom) == atomMap->end()) {
+                (*atomMap)[oAtom] = maxRolledRadius + 1;
+              } else {
+                (*atomMap)[oAtom] = std::min(atomMap->at(oAtom), maxRolledRadius + 1);
+              }
+            }
+            // if we're going to do another iteration, then push the neighbors from
+            // this round onto the stack
+            if (maxRolledRadius < radius - 1) {
+              for (const auto bond : mol.atomBonds(mol.getAtomWithIdx(oAtom))) {
+                if (!bondsIn.test(bond->getIdx())) {
+                  if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(oAtom))
+                                       ->getAtomicNum() != 1) {
+                    nextLayer.emplace_back(oAtom, bond->getIdx());
+                  }
+                }
+              }
+            }
+          }
+        }
+        nbrStack = std::move(nextLayer);
+      }
+      return maxRolledRadius;
+    }
+}
+
 PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs, bool enforceSize,
@@ -545,79 +613,85 @@ PATH_TYPE findAtomEnvironmentOfRadiusN(
   if (rootedAtAtom >= mol.getNumAtoms()) {
     throw ValueErrorException("bad atom index");
   }
-  if (atomMap) {
-    atomMap->clear();
-  }
   PATH_TYPE res;
   if (atomMap) {
+    atomMap->clear();
     (*atomMap)[rootedAtAtom] = 0;
   }
+  
   if (radius == 0) {
     return res;
   }  // Return empty path if radius=0
 
   std::list<std::pair<int, int>> nbrStack;
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = mol.getAtomBonds(mol.getAtomWithIdx(rootedAtAtom));
-  while (beg != end) {
-    const Bond *bond = mol[*beg];
-    if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(rootedAtAtom))
-                         ->getAtomicNum() != 1) {
-      nbrStack.emplace_back(rootedAtAtom, bond->getIdx());
-    }
-    ++beg;
-  }
+  // Select all neighboring bonds for iteration
+  prepareNeighborStack(mol, rootedAtAtom, nbrStack, useHs);
+
+  // Perform BFS to find the environment
   boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
-  unsigned int i;
-  for (i = 0; i < radius; ++i) {
-    if (nbrStack.empty()) {
-      break;
-    }
-
-    std::list<std::pair<int, int>> nextLayer;
-    while (!nbrStack.empty()) {
-      int bondIdx, startAtom;
-      boost::tie(startAtom, bondIdx) = nbrStack.front();
-      nbrStack.pop_front();
-      if (!bondsIn.test(bondIdx)) {
-        bondsIn.set(bondIdx);
-        res.push_back(bondIdx);
-
-        // add the next set of neighbors:
-        int oAtom = mol.getBondWithIdx(bondIdx)->getOtherAtomIdx(startAtom);
-        if (atomMap) {
-          if (atomMap->find(oAtom) == atomMap->end()) {
-            (*atomMap)[oAtom] = i + 1;
-          } else {
-            (*atomMap)[oAtom] = std::min(atomMap->at(oAtom), i + 1);
-          }
-        }
-        // if we're going to do another iteration, then push the neighbors from
-        // this round onto the stack
-        if (i < radius - 1) {
-          for (const auto bond : mol.atomBonds(mol.getAtomWithIdx(oAtom))) {
-            if (!bondsIn.test(bond->getIdx())) {
-              if (useHs || mol.getAtomWithIdx(bond->getOtherAtomIdx(oAtom))
-                                   ->getAtomicNum() != 1) {
-                nextLayer.emplace_back(oAtom, bond->getIdx());
-              }
-            }
-          }
-        }
+  unsigned int maxRolledRadius = findEnvironmentOfRadiusN(mol, radius, res, nbrStack,
+                                                          bondsIn, useHs, atomMap);
+  if (enforceSize) {
+    if (maxRolledRadius != radius) {
+      // If there are no paths found with the requested radius, user can choose
+      // whether or not to return nothing in this case. If enforceSize=true,
+      // this is similar to the previous bahviour (return an empty path/vector).
+      res.clear();
+      res.resize(0);
+      if (atomMap) {
+        atomMap->clear();
       }
     }
-    nbrStack = std::move(nextLayer);
   }
-  if (i != radius && enforceSize) {
-    // If there are no paths found with the requested radius, user can choose
-    // whether or not to return nothing in this case. If enforceSize=true, this
-    // is similar to the previous bahviour (return an empty path/vector).
-    // Otherwise, it collect every path within the requested radius. This is
-    // similar to maxPath(mol, res) <= radius.
-    res.clear();
-    res.resize(0);
-    if (atomMap) {
-      atomMap->clear();
+  
+  return res;
+}
+
+
+PATH_TYPE findBondEnvironmentOfRadiusN(
+    const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
+    bool useHs, bool enforceSize,
+    std::unordered_map<unsigned int, unsigned int> *atomMap) {
+  if (rootedAtBond >= mol.getNumBonds()) {
+    throw ValueErrorException("bad bond index");
+  }
+  PATH_TYPE res;
+  const Bond &rootedBond = *mol.getBondWithIdx(rootedAtBond);
+  unsigned int beginAtomIdx = rootedBond.getBeginAtomIdx();
+  unsigned int endAtomIdx = rootedBond.getEndAtomIdx();
+  
+  if (atomMap) {
+    atomMap->clear();
+    (*atomMap)[beginAtomIdx] = 0;
+    (*atomMap)[endAtomIdx] = 0;
+  }
+
+  if (radius == 0) {
+    return res;
+  }  // Return empty path if radius=0
+
+  std::list<std::pair<int, int>> nbrStack;
+  // Select all neighboring bonds for iteration, the rooted bond is ignored
+  prepareNeighborStack(mol, beginAtomIdx, nbrStack, useHs); 
+  prepareNeighborStack(mol, endAtomIdx, nbrStack, useHs); 
+  
+  // Duplicated at rooted bond is available, but we set the constraint below. 
+  // Perform BFS to find the environment
+  boost::dynamic_bitset<> bondsIn(mol.getNumBonds());
+  res.push_back(rootedAtBond);
+  bondsIn.set(rootedAtBond);
+  unsigned int maxRolledRadius = findEnvironmentOfRadiusN(mol, radius, res, nbrStack, 
+                                                          bondsIn, useHs, atomMap);
+  if (enforceSize) {
+    if (maxRolledRadius != radius) {
+      // If there are no paths found with the requested radius, user can choose
+      // whether or not to return nothing in this case. If enforceSize=true,
+      // this is similar to the previous bahviour (return an empty path/vector).
+      res.clear();
+      res.resize(0);
+      if (atomMap) {
+        atomMap->clear();
+      }
     }
   }
   return res;

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -128,6 +128,7 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
     bool useBonds = true, bool useHs = false, int rootedAtAtom = -1);
 
 //! \brief Find bond subgraphs of a particular radius around an atom.
+//!        The result is a path (a vector of bond indices).
 //!        Return empty result if there is no bond at the requested radius.
 /*!
  *   \param mol - the molecule to be considered
@@ -138,16 +139,41 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
  *                      Hs to the graph.
  *   \param enforceSize - If false, all the bonds within the requested radius
  *                        (<= radius) is collected. Otherwise, at least one bond
- *                        located at the requested radius must be found and
- * added. \param atomMap - Optional: If provided, it will measure the minimum
+ *                        located at the asked radius must be found and added. 
+ *   \param atomMap - Optional: If provided, it will measure the minimum
  * distance of the atom from the rooted atom (start with 0 from the rooted
- * atom). The result is a pair of the atom ID and the distance. The result is a
- * path (a vector of bond indices)
+ * atom). The result is a pair of the atom ID and the distance.
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findAtomEnvironmentOfRadiusN(
     const ROMol &mol, unsigned int radius, unsigned int rootedAtAtom,
     bool useHs=false, bool enforceSize=true,
     std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+
+//! \brief Find bond subgraphs of a particular radius around a bond. 
+//!        The result is a path (a vector of bond indices).
+//!        Return empty result if there is no bond at the requested radius.
+//!        The function is equivalent as `findAtomEnvironmentOfRadiusN` on 
+//!        two connected atoms, and uniquely aggregate together with minimal 
+//!        bond distance.
+/*!
+ *   \param mol - the molecule to be considered
+ *   \param radius - the radius of the subgraphs to be considered
+ *   \param rootedAtBond - the bond to consider
+ *   \param useHs     - if set, hydrogens in the graph will be considered
+ *                      eligible to be in paths. NOTE: this will not add
+ *                      Hs to the graph.
+ *   \param enforceSize - If false, all the bonds within the requested radius
+ *                        (<= radius) is collected. Otherwise, at least one bond
+ *                        located at the asked radius must be found and added. 
+ *   \param atomMap - Optional: If provided, it will measure the minimum
+ * distance of the atom from the connected bond (start with 0 from the connected
+ * atom). The result is a pair of the atom ID and the distance. 
+ */
+RDKIT_SUBGRAPHS_EXPORT PATH_TYPE findBondEnvironmentOfRadiusN(
+    const ROMol &mol, unsigned int radius, unsigned int rootedAtBond,
+    bool useHs=false, bool enforceSize=true,
+    std::unordered_map<unsigned int, unsigned int> *atomMap=nullptr);
+
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -326,7 +326,7 @@ void test4() {
 
   {
     // Non-ring-membered bond;
-    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO" // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
+    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO"; // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
     unsigned int rootedAtBond = 8; // S-S bond
  
     RWMol *mol = SmilesToMol(smiles);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -378,7 +378,7 @@ void test4() {
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
-      cAtomMap.clear(); 
+      cAtomMap.clear();
     }
   
     // ---------------------------------------------------------------------------------

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -428,7 +428,7 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::string smiles = "C1CCCSSCCC1"; 
+    std::string smiles = "C1CCCNNCCC1"; 
     unsigned int rootedAtBond = 4;
 
     RWMol *mol = SmilesToMol(smiles);
@@ -470,13 +470,17 @@ void test4() {
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
-
+      // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
       cAtomMap.clear();
       
-      // ---------------------------------------------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
+      
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
       TEST_ASSERT(pth.size() == 9);
       TEST_ASSERT(cAtomMap.size() == 9);
@@ -492,34 +496,34 @@ void test4() {
     // useHs = true
     {
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 3);
-      TEST_ASSERT(cAtomMap.size() == 4);
+      TEST_ASSERT(pth.size() == 5);
+      TEST_ASSERT(cAtomMap.size() == 6);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 9);
-      TEST_ASSERT(cAtomMap.size() == 10);
+      TEST_ASSERT(pth.size() == 11);
+      TEST_ASSERT(cAtomMap.size() == 12);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 15);
-      TEST_ASSERT(cAtomMap.size() == 16);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 21);
-      TEST_ASSERT(cAtomMap.size() == 21);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 23);
-      TEST_ASSERT(cAtomMap.size() == 23);
+      TEST_ASSERT(pth.size() == 25);
+      TEST_ASSERT(cAtomMap.size() == 25);
       cAtomMap.clear();
       
       // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 23);
-      TEST_ASSERT(cAtomMap.size() == 23);
+      TEST_ASSERT(pth.size() == 25);
+      TEST_ASSERT(cAtomMap.size() == 25);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -320,6 +320,220 @@ void test3() {
   std::cout << "Finished" << std::endl;
 }
 
+void test4() {
+  std::cout << "-----------------------" << std::endl;
+  std::cout << "Test 4: Bond Environment" << std::endl;
+
+  {
+    // Non-ring-membered bond;
+    std::string smiles = "C=NC(CNC)(NO)SSC(CNC)(N=C)NO" // Non-canonical "S(C(CNC)(N=C)NO)S(C(CNC)(N=C)NO)"
+    unsigned int rootedAtBond = 8; // S-S bond
+ 
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    PATH_TYPE pth;
+    
+    // ---------------------------------------------------------------------------------
+    // Zero radius
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[8] == 0);
+    TEST_ASSERT(cAtomMap[9] == 0);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = false
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
+      
+      // -------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 17);
+      TEST_ASSERT(cAtomMap.size() == 18);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+  
+    // ---------------------------------------------------------------------------------
+    // useHs = true
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 21);
+      TEST_ASSERT(cAtomMap.size() == 22);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 31);
+      TEST_ASSERT(cAtomMap.size() == 32);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 37);
+      TEST_ASSERT(cAtomMap.size() == 38);
+      cAtomMap.clear();
+
+      // -------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 37);
+      TEST_ASSERT(cAtomMap.size() == 38);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+
+    delete mol;
+    delete mH;
+  }
+
+  {
+    // Ring-membered bond;
+    std::string smiles = "C1CCCSSCCC1"; 
+    unsigned int rootedAtBond = 4;
+
+    RWMol *mol = SmilesToMol(smiles);
+    TEST_ASSERT(mol);
+    ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
+
+    std::unordered_map<unsigned int, unsigned int> cAtomMap;
+    PATH_TYPE pth;
+
+    // ---------------------------------------------------------------------------------
+    // Zero radius
+    pth = findBondEnvironmentOfRadiusN(*mH, 0, rootedAtBond, true, false, &cAtomMap);
+    TEST_ASSERT(pth.size() == 1);
+    TEST_ASSERT(pth[0] == rootedAtBond);
+    TEST_ASSERT(cAtomMap.size() == 2);
+    TEST_ASSERT(cAtomMap[4] == 0);
+    TEST_ASSERT(cAtomMap[5] == 0);
+    cAtomMap.clear();
+
+    // ---------------------------------------------------------------------------------
+    // useHs = false
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 5);
+      TEST_ASSERT(cAtomMap.size() == 6);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 7);
+      TEST_ASSERT(cAtomMap.size() == 8);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
+      
+      // ---------------------------------------------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 9);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, false, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+
+    // ---------------------------------------------------------------------------------
+    // useHs = true
+    {
+      pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 21);
+      TEST_ASSERT(cAtomMap.size() == 21);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
+      cAtomMap.clear();
+      
+      // ---------------------------------------------------------------------------------
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
+      cAtomMap.clear();
+
+      pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);
+      TEST_ASSERT(pth.size() == 0);
+      TEST_ASSERT(cAtomMap.size() == 0);
+      cAtomMap.clear();
+    }
+
+    delete mol;
+    delete mH;
+  }
+
+  std::cout << "Finished" << std::endl;
+}
+
 void testGithubIssue103() {
   std::cout << "-----------------------\n Testing github Issue103: "
                "stereochemistry and pathToSubmol"
@@ -386,6 +600,7 @@ int main() {
   test1();
   test2();
   test3();
+  test4();
   testGithubIssue103();
   testGithubIssue2647();
   return 0;

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -378,7 +378,7 @@ void test4() {
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, false, true, &cAtomMap);
       TEST_ASSERT(pth.size() == 0);
       TEST_ASSERT(cAtomMap.size() == 0);
-      cAtomMap.clear();
+      cAtomMap.clear(); 
     }
   
     // ---------------------------------------------------------------------------------

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -68,6 +68,7 @@ void test1() {
   std::cout << "Finished" << std::endl;
 }
 
+
 void test2() {
   std::cout << "-----------------------\n Test2: Atom Environments"
             << std::endl;

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -68,7 +68,6 @@ void test1() {
   std::cout << "Finished" << std::endl;
 }
 
-
 void test2() {
   std::cout << "-----------------------\n Test2: Atom Environments"
             << std::endl;
@@ -428,7 +427,7 @@ void test4() {
 
   {
     // Ring-membered bond;
-    std::string smiles = "C1CCCNNCCC1"; 
+    std::string smiles = "C1CCCSSCCC1"; 
     unsigned int rootedAtBond = 4;
 
     RWMol *mol = SmilesToMol(smiles);
@@ -496,34 +495,34 @@ void test4() {
     // useHs = true
     {
       pth = findBondEnvironmentOfRadiusN(*mH, 1, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 5);
-      TEST_ASSERT(cAtomMap.size() == 6);
+      TEST_ASSERT(pth.size() == 3);
+      TEST_ASSERT(cAtomMap.size() == 4);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 2, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 11);
-      TEST_ASSERT(cAtomMap.size() == 12);
+      TEST_ASSERT(pth.size() == 9);
+      TEST_ASSERT(cAtomMap.size() == 10);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 3, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 17);
-      TEST_ASSERT(cAtomMap.size() == 18);
+      TEST_ASSERT(pth.size() == 15);
+      TEST_ASSERT(cAtomMap.size() == 16);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 4, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 23);
-      TEST_ASSERT(cAtomMap.size() == 23);
+      TEST_ASSERT(pth.size() == 21);
+      TEST_ASSERT(cAtomMap.size() == 21);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 5, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 25);
-      TEST_ASSERT(cAtomMap.size() == 25);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
       
       // ---------------------------------------------------------------------------------
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, false, &cAtomMap);
-      TEST_ASSERT(pth.size() == 25);
-      TEST_ASSERT(cAtomMap.size() == 25);
+      TEST_ASSERT(pth.size() == 23);
+      TEST_ASSERT(cAtomMap.size() == 23);
       cAtomMap.clear();
 
       pth = findBondEnvironmentOfRadiusN(*mH, 6, rootedAtBond, true, true, &cAtomMap);


### PR DESCRIPTION
**Why does this PR:** 
I did the small project in which the properties of a particular atom inside a molecule can be predicted within a defined subgraph. The core idea worked well with `Subsgraph::findAtomEnvironmentOfRadiusN()`. But I don't like I have to write extra code to match up the `bondPath` and `radius`, so PR #4970 is introduced.

My second project is aimed on the particular bond (its property can also be predictable within a defined radius). 
In the legacy version, I have to merge the result from both connected atoms. Let's say the `bondID=5, atomIdx=(4, 5)`; thus I have to perform `Subsgraph::findAtomEnvironmentOfRadiusN()` twice and uniquely aggregating the result to run `pathToSubmol()`. Although there are zero issues arised but the time spent is relatively large `O(2 * (N*d))`. 

**What needed to be implemented** 
- Generalize the function `findAtomEnvironmentOfRadiusN()` into two smaller components which are `prepareNeighborStack()` and `findEnvironmentOfRadiusN()` into a private namespace -> Reduce testing
- Add test: The result in a defined behaviour (the radius of each `bondIdx` in `bondPath` is partially deterministic and predictable). The test will only two types bond type: ring-membered bond and non-ring-membered bond

**Result**
- Reduce time complexity from `2 * (N**d)` to `N**d + N`

**Future Work**
None, but if successfully, I wished the function `bond.getNeighborBonds()` or `bond.getBonds()` (by RDKit notation) can be implemented using the idea of `findBondEnvironmentOfRadiusN()`